### PR TITLE
Update slack channel associated with ownership.yaml

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -7,7 +7,7 @@ ownership:
   tier: 2
   kind: artifact
   team: github/c2c-actions-runtime
-  team_slack: actions-runners
+  team_slack: actions-runtime
   repo: https://github.com/actions/alpine_nodejs
   maintainer: benwells
   exec_sponsor: isethi


### PR DESCRIPTION
Updating ownership.yaml slack channel to actions-runtime as the previous channel is no longer correct.