### PR TITLE
Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-release-alpine-nodejs.yml
+++ b/.github/workflows/build-release-alpine-nodejs.yml
@@ -32,7 +32,7 @@ jobs:
          docker run --rm -v $RUNNER_TEMP/alpine_node:/node_output alpine_nodejs:${{github.event.inputs.NodeVersion}}
          ls -l -R $RUNNER_TEMP/alpine_node
     - name: Upload alpine node.js
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
         path:  ${{runner.temp}}/alpine_node/node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
@@ -44,7 +44,7 @@ jobs:
     container: alpine
     steps:
     - name: Download alpine node.js
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
     - run: |
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download alpine node.js
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
     # Create GitHub release


### PR DESCRIPTION
Versions at or below v3 are deprecated and will be unusable in November.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/