### PR TITLE
Build for arm64 too

### DIFF
--- a/.github/workflows/build-release-alpine-nodejs.yml
+++ b/.github/workflows/build-release-alpine-nodejs.yml
@@ -13,19 +13,31 @@ jobs:
   build:
     name: Build node.js ${{github.event.inputs.NodeVersion}}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ['x64', 'arm64']
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
       run: |
          NodeVersion="${{github.event.inputs.NodeVersion}}"
          PythonVersion="python3"
+         Arch="${{matrix.arch}}"
          if [[ $NodeVersion = v12* ]]
          then
            PythonVersion="python2"
          fi
+
+         DockerPlatform="linux/amd64"
+         if [[ $Arch = arm64 ]]
+         then
+           DockerPlatform="linux/arm64"
+         fi
+
          echo node.js version $NodeVersion
          echo python version $PythonVersion
-         docker build --file Dockerfile --tag alpine_nodejs:${{github.event.inputs.NodeVersion}} --build-arg NodeVersion=${{github.event.inputs.NodeVersion}} --build-arg PythonVersion=$PythonVersion .
+         echo arch $Arch
+         docker build --file Dockerfile --tag alpine_nodejs:${{github.event.inputs.NodeVersion}} --build-arg NodeVersion=${{github.event.inputs.NodeVersion}} --build-arg PythonVersion=$PythonVersion --build-arg Arch=$Arch --platform $DockerPlatform .
     - name: Copy alpine node.js out
       run: |
          mkdir $RUNNER_TEMP/alpine_node
@@ -34,22 +46,29 @@ jobs:
     - name: Upload alpine node.js
       uses: actions/upload-artifact@v3
       with:
-        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
-        path:  ${{runner.temp}}/alpine_node/node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
+        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}_${{matrix.arch}}
+        path:  ${{runner.temp}}/alpine_node/node-${{github.event.inputs.NodeVersion}}-alpine-${{matrix.arch}}.tar.gz
 
   test:
     name: Test node.js ${{github.event.inputs.NodeVersion}}
     needs: [build]
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            runs-on: ubuntu-latest
+          - arch: arm64
+            runs-on: ubuntu-latest # TODO: Add and use an ARM64 runner
+    runs-on: ${{matrix.runs-on}}
     container: alpine
     steps:
     - name: Download alpine node.js
       uses: actions/download-artifact@v3
       with:
-        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
+        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}_${{matrix.arch}}
     - run: |
         ls -l
-        tar xzf ./node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
+        tar xzf ./node-${{github.event.inputs.NodeVersion}}-alpine-${{matrix.arch}}.tar.gz
         ls -l -R
         ./bin/node -v
         ./bin/node -e "console.log('hello world')"
@@ -61,10 +80,14 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-    - name: Download alpine node.js
+    - name: Download x64 alpine node.js
       uses: actions/download-artifact@v3
       with:
-        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
+        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}_x64
+    - name: Download arm64 alpine node.js
+      uses: actions/download-artifact@v3
+      with:
+        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}_arm64
     # Create GitHub release
     - uses: actions/create-release@master
       id: createRelease
@@ -85,4 +108,13 @@ jobs:
         upload_url: ${{ steps.createRelease.outputs.upload_url }}
         asset_path: ${{ github.workspace }}/node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
         asset_name: node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
+        asset_content_type: application/octet-stream
+    - name: Upload Release Asset # TODO: Verify if this works
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.createRelease.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/node-${{github.event.inputs.NodeVersion}}-alpine-arm64.tar.gz
+        asset_name: node-${{github.event.inputs.NodeVersion}}-alpine-arm64.tar.gz
         asset_content_type: application/octet-stream

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine
 ARG NodeVersion
 ARG PythonVersion
+ARG Arch
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -11,7 +12,7 @@ RUN apk add --no-cache --virtual .build-deps binutils-gold curl g++ gcc gnupg li
 
 # donwload and compile node from source code.
 RUN wget https://nodejs.org/dist/$NodeVersion/node-$NodeVersion.tar.gz && tar -zxvf node-$NodeVersion.tar.gz
-RUN cd node-$NodeVersion && ./configure --dest-cpu=x64 --partly-static && make -j$(getconf _NPROCESSORS_ONLN)
+RUN cd node-$NodeVersion && ./configure --dest-cpu=$Arch --partly-static && make -j$(getconf _NPROCESSORS_ONLN)
 
 # create and copy tar.gz into /node_staging
 RUN mkdir -p /usr/src/out/bin
@@ -19,8 +20,8 @@ RUN mkdir -p /node_staging
 WORKDIR /usr/src/out
 RUN cp /usr/src/app/node-$NodeVersion/out/Release/node /usr/src/out/bin/node
 RUN cp /usr/src/app/node-$NodeVersion/LICENSE /usr/src/out/LICENSE
-RUN tar -czvf node-$NodeVersion-alpine-x64.tar.gz ./bin ./LICENSE && rm -rf ./bin ./LICENSE
-RUN cp ./node-$NodeVersion-alpine-x64.tar.gz /node_staging/node-$NodeVersion-alpine-x64.tar.gz && ls -l /node_staging
+RUN tar -czvf node-$NodeVersion-alpine-$Arch.tar.gz ./bin ./LICENSE && rm -rf ./bin ./LICENSE
+RUN cp ./node-$NodeVersion-alpine-$Arch.tar.gz /node_staging/node-$NodeVersion-alpine-$Arch.tar.gz && ls -l /node_staging
 
 # copy the tar.gz into the mapped in volume
 CMD ["cp", "-v", "-a", "/node_staging/.", "/node_output/"]


### PR DESCRIPTION
We can build for ARM64 similarly to how we build for x64, just need to pass the architecture info here and there.

Helps fix https://github.com/orgs/community/discussions/53407 and https://github.com/actions/runner/issues/801. (Doesn't actually fix, because changes will also be required in the Actions Worker, but this is a good start.)

There are two to-dos:
1. Set up an ARM64 runner for testing the ARM64 binary (comment left in matrix).
2. Ensure uploading multiple artifacts like this works (not sure, also this is an outdated upload-artifact action).

I have build Node manually on my computer like this (M1 on ARM alpine). It worked!