### PR TITLE
Add arm64 support

### DIFF
--- a/.github/workflows/build-release-alpine-nodejs.yml
+++ b/.github/workflows/build-release-alpine-nodejs.yml
@@ -11,8 +11,15 @@ on:
 
 jobs:
   build:
-    name: Build node.js ${{github.event.inputs.NodeVersion}}
-    runs-on: ubuntu-latest
+    name: Build node.js ${{github.event.inputs.NodeVersion}} (${{matrix.arch}})
+    runs-on: ${{matrix.runner}}
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
@@ -25,7 +32,11 @@ jobs:
          fi
          echo node.js version $NodeVersion
          echo python version $PythonVersion
-         docker build --file Dockerfile --tag alpine_nodejs:${{github.event.inputs.NodeVersion}} --build-arg NodeVersion=${{github.event.inputs.NodeVersion}} --build-arg PythonVersion=$PythonVersion .
+         docker build --file Dockerfile --tag alpine_nodejs:${{github.event.inputs.NodeVersion}} \
+         --build-arg NodeVersion=${{github.event.inputs.NodeVersion}} \
+         --build-arg PythonVersion=$PythonVersion \
+         --build-arg NodeArch=${{matrix.arch}} \
+         .
     - name: Copy alpine node.js out
       run: |
          mkdir $RUNNER_TEMP/alpine_node
@@ -34,22 +45,29 @@ jobs:
     - name: Upload alpine node.js
       uses: actions/upload-artifact@v4
       with:
-        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
-        path:  ${{runner.temp}}/alpine_node/node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
+        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}_${{matrix.arch}}
+        path: ${{runner.temp}}/alpine_node/node-${{github.event.inputs.NodeVersion}}-alpine-${{matrix.arch}}.tar.gz
 
   test:
     name: Test node.js ${{github.event.inputs.NodeVersion}}
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.runner}}
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     container: alpine
     steps:
     - name: Download alpine node.js
       uses: actions/download-artifact@v4
       with:
-        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
+        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}_${{matrix.arch}}
     - run: |
         ls -l
-        tar xzf ./node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
+        tar xzf ./node-${{github.event.inputs.NodeVersion}}-alpine-${{matrix.arch}}.tar.gz
         ls -l -R
         ./bin/node -v
         ./bin/node -e "console.log('hello world')"
@@ -61,28 +79,17 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-    - name: Download alpine node.js
+    - name: Download alpine node.js (x64 and arm64)
       uses: actions/download-artifact@v4
       with:
-        name: alpine_nodejs_${{github.event.inputs.NodeVersion}}
-    # Create GitHub release
-    - uses: actions/create-release@master
-      id: createRelease
-      name: Create node.js ${{github.event.inputs.NodeVersion}} Alpine Release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        pattern: alpine_nodejs_${{github.event.inputs.NodeVersion}}_*
+        merge-multiple: true
+    - name: Release
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: "${{github.event.inputs.NodeVersion}}"
-        release_name: "${{github.event.inputs.NodeVersion}}"
+        name: "${{github.event.inputs.NodeVersion}}"
         body: |
           Alpine node.js ${{github.event.inputs.NodeVersion}}
-    # Upload release assets
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.createRelease.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
-        asset_name: node-${{github.event.inputs.NodeVersion}}-alpine-x64.tar.gz
-        asset_content_type: application/octet-stream
+        files: |
+          node-*-alpine-*.tar.gz

--- a/.github/workflows/build-release-alpine-nodejs.yml
+++ b/.github/workflows/build-release-alpine-nodejs.yml
@@ -49,7 +49,7 @@ jobs:
         path: ${{runner.temp}}/alpine_node/node-${{github.event.inputs.NodeVersion}}-alpine-${{matrix.arch}}.tar.gz
 
   test:
-    name: Test node.js ${{github.event.inputs.NodeVersion}}
+    name: Test node.js ${{github.event.inputs.NodeVersion}} (${{matrix.arch}})
     needs: [build]
     runs-on: ${{matrix.runner}}
     strategy:
@@ -57,8 +57,10 @@ jobs:
         include:
           - arch: x64
             runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
+          # TODO enable running the tests on arm64 once actions/runner supports Alpine arm64
+          # https://github.com/actions/runner/pull/3665
+          #- arch: arm64
+          #  runner: ubuntu-24.04-arm
     container: alpine
     steps:
     - name: Download alpine node.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine
 ARG NodeVersion
 ARG PythonVersion
+ARG NodeArch
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -11,7 +12,7 @@ RUN apk add --no-cache --virtual .build-deps binutils-gold curl g++ gcc gnupg li
 
 # donwload and compile node from source code.
 RUN wget https://nodejs.org/dist/$NodeVersion/node-$NodeVersion.tar.gz && tar -zxvf node-$NodeVersion.tar.gz
-RUN cd node-$NodeVersion && ./configure --dest-cpu=x64 --partly-static && make -j$(getconf _NPROCESSORS_ONLN)
+RUN cd node-$NodeVersion && ./configure --dest-cpu=$NodeArch --partly-static && make -j$(getconf _NPROCESSORS_ONLN)
 
 # create and copy tar.gz into /node_staging
 RUN mkdir -p /usr/src/out/bin
@@ -19,8 +20,8 @@ RUN mkdir -p /node_staging
 WORKDIR /usr/src/out
 RUN cp /usr/src/app/node-$NodeVersion/out/Release/node /usr/src/out/bin/node
 RUN cp /usr/src/app/node-$NodeVersion/LICENSE /usr/src/out/LICENSE
-RUN tar -czvf node-$NodeVersion-alpine-x64.tar.gz ./bin ./LICENSE && rm -rf ./bin ./LICENSE
-RUN cp ./node-$NodeVersion-alpine-x64.tar.gz /node_staging/node-$NodeVersion-alpine-x64.tar.gz && ls -l /node_staging
+RUN tar -czvf node-$NodeVersion-alpine-$NodeArch.tar.gz ./bin ./LICENSE && rm -rf ./bin ./LICENSE
+RUN cp ./node-$NodeVersion-alpine-$NodeArch.tar.gz /node_staging/node-$NodeVersion-alpine-$NodeArch.tar.gz && ls -l /node_staging
 
 # copy the tar.gz into the mapped in volume
 CMD ["cp", "-v", "-a", "/node_staging/.", "/node_output/"]


### PR DESCRIPTION
Successor of https://github.com/actions/alpine_nodejs/pull/7

Uses the now-available `ubuntu-24.04-arm` runner to run natively on arm64.

Here's a test run: https://github.com/dennisameling/alpine_nodejs/actions/runs/12998098115

And here's the release it created: https://github.com/dennisameling/alpine_nodejs/releases/tag/v20.18.2